### PR TITLE
 Tillfällig flaggdag 17 december 2018

### DIFF
--- a/alma.py
+++ b/alma.py
@@ -570,6 +570,7 @@ class YearCal:
 	    (None, None, 11,  6, BLACK, True,  None), # Gustav Adolfsdagen
 	    (None, None, 12, 10, BLACK, True,  "Nobeldagen"),
 	    (2018, None,  5, 29, BLACK, True, "Veterandagen"),
+	    (2018, 2018,  12, 17, BLACK, True, "Minnesdag för demokratins genombrott"), # Tillfällig flaggdag 2018, enligt 2017/18:KU28
 
 	    # Flaggdagar för regerande kungahuset
 	    


### PR DESCRIPTION
Tillfällig flaggdag 17 december 2018  …
"Riksdagen ställer sig bakom det som anförs i motionen om tillägg i
förordningen (1982:270) om allmänna flaggdagar genom införande av den
17 december 2018 som tillfällig allmän flaggdag och tillkännager detta
för regeringen."
https://www.riksdagen.se/sv/dokument-lagar/dokument/motion/flaggdag-for-
demokratin_H5021467

"Beslutet är historiskt då detta är första gången en flaggdag införs
vid endast ett tillfälle."
https://www.metro.se/artikel/historiska-beslutet-sverige-inf%C3%B6r-till
f%C3%A4llig-flaggdag