### PR TITLE
Tillfällig flaggdag 15 september 2023

### DIFF
--- a/alma.py
+++ b/alma.py
@@ -724,6 +724,7 @@ class YearCal:
 	    (1939, None, 12, 10, BLACK, True,  "Nobeldagen"),
 	    (2018, None,  5, 29, BLACK, True, "Veterandagen"),
 	    (2018, 2018,  12, 17, BLACK, True, "Minnesdag för demokratins genombrott"), # Tillfällig flaggdag 2018, enligt 2017/18:KU28
+	    (2023, 2023,  9, 15, BLACK, True, "50-årsdagen av kung Carl XVI Gustafs trontillträde"), # Tillfällig flaggdag 2023, enligt 2022/23:KU41
 
 	    # Flaggdagar för regerande kungahuset
 	    


### PR DESCRIPTION
> Den 15 september 2023 blir en tillfällig allmän flaggdag för att högtidlighålla 50-årsdagen av kung Carl XVI Gustafs trontillträde. Riksdagen sa ja till regeringens förslag.

https://www.riksdagen.se/sv/dokument-och-lagar/dokument/betankande/en-tillfallig-allman-flaggdag-for-att_ha01ku41/